### PR TITLE
Return a service not found error for systemd

### DIFF
--- a/services/systemd.go
+++ b/services/systemd.go
@@ -70,7 +70,7 @@ func (s *Systemd) LookupService(serviceName string) (*ProcessStatus, error) {
 	}
 
 	if err != nil {
-		return nil, &ServiceError{s.Name(), serviceName, err}
+		return nil, &ServiceError{s.Name(), serviceName, ErrServiceNotFound}
 	}
 	lines, err := util.ReadLines(sout)
 	if len(lines) != 1 {
@@ -95,6 +95,7 @@ func (s *Systemd) LookupService(serviceName string) (*ProcessStatus, error) {
 		cmd := exec.Command("systemctl", "is-enabled", serviceName)
 		sout, err = util.SafeRun(cmd)
 	}
+
 	if err != nil || string(sout) != "enabled\n" {
 		return nil, &ServiceError{s.Name(), serviceName, ErrServiceNotFound}
 	} else {


### PR DESCRIPTION
Systemd would return the actual error that was thrown during detection, rather
than the ErrServiceNotFound that detection expected. Because initd detection
always followed systemd detection initd services wouldn't be resolved
correctly.
