### PR TITLE
Fix email templates To/From to conform to RFC 5322

### DIFF
--- a/templates/email/ProcessDoesNotExist.txt
+++ b/templates/email/ProcessDoesNotExist.txt
@@ -1,5 +1,5 @@
-To: {{.Config.To}} <{{.Config.To}}>
-From: {{.Config.From}} <{{.Config.From}}>
+To: <{{.Config.To}}>
+From: <{{.Config.From}}>
 Subject: {{.Target}} does not exist.
 
 I can't locate a process for the {{.Thing.Name}} service on {{.Hostname}}.

--- a/templates/email/ProcessExists.txt
+++ b/templates/email/ProcessExists.txt
@@ -1,5 +1,5 @@
-To: {{.Config.To}} <{{.Config.To}}>
-From: {{.Config.From}} <{{.Config.From}}>
+To: <{{.Config.To}}>
+From: <{{.Config.From}}>
 Subject: {{.Target}} is now running.
 
 The {{.Thing.Name}} service is now running with PID {{.Service.Process.Pid}}

--- a/templates/email/RuleFailed.txt
+++ b/templates/email/RuleFailed.txt
@@ -1,5 +1,5 @@
-To: {{.Config.To}} <{{.Config.To}}>
-From: {{.Config.From}} <{{.Config.From}}>
+To: <{{.Config.To}}>
+From: <{{.Config.From}}>
 Subject: {{.Target}} {{.Rule.Metric}} has failed its check{{.Rule.Consequence}}
 
 {{.Rule.Metric}} is {{.Rule.Op}} than {{.Rule.DisplayThreshold}} for {{.Target}}

--- a/templates/email/RuleRecovered.txt
+++ b/templates/email/RuleRecovered.txt
@@ -1,5 +1,5 @@
-To: {{.Config.To}} <{{.Config.To}}>
-From: {{.Config.From}} <{{.Config.From}}>
+To: <{{.Config.To}}>
+From: <{{.Config.From}}>
 Subject: {{.Target}} {{.Rule.Metric}} has recovered
 
 {{.Target}} {{.Rule.Metric}} has recovered.


### PR DESCRIPTION
This removes the duplicate mention of the email address in the To: and From: headers of templates, because the @ character is not allowed as part of an atom.

It would only be allowed if the email address in the name part was quoted.

Details: [RFC 5322 Section 3.2.3](http://tools.ietf.org/html/rfc5322#section-3.2.3) (Atom Definition)

This fixes display and reply problems in Apple Mail which would display `foo@` for the bad example given below and build a wrong reply address `"foo@" <example.org foo@example.org>`.

Examples:

```
[BAD] foo@example.org <foo@example.org>
[OK] <foo@example.org>
[OK] "foo@example.org" <foo@example.org>
```
