### PR TITLE
[RFC] Allow plain and unauthenticated smtp

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -179,11 +179,18 @@ func sendEmail(e *EmailNotifier, doc bytes.Buffer) error {
 	} else {
 		util.Debug("Sending email to %s", e.To)
 		util.Debug("Sending email:\n%s", string(doc.Bytes()))
-		auth := smtp.PlainAuth("", e.Username, e.Password, e.Host)
-		err := smtp.SendMail(e.Host+":587", auth, e.From,
-			[]string{e.To}, doc.Bytes())
-		if err != nil {
-			return err
+		if e.Username != "" {
+			auth := smtp.PlainAuth("", e.Username, e.Password, e.Host)
+			err := smtp.SendMail(e.Host+":587", auth, e.From,
+				[]string{e.To}, doc.Bytes())
+			if err != nil {
+				return err
+			}
+		} else {
+			err := smtp.SendMail(e.Host+":25", nil, e.From, []string{e.To}, doc.Bytes())
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -192,11 +199,11 @@ func sendEmail(e *EmailNotifier, doc bytes.Buffer) error {
 func (e *EmailNotifier) setup(hash map[string]string) error {
 	usr, ok := hash["username"]
 	if !ok {
-		return errors.New("You must have a username configured to send email")
+		usr = ""
 	}
 	pwd, ok := hash["password"]
 	if !ok {
-		return errors.New("You must have a password configured to send email")
+		pwd = ""
 	}
 	host, ok := hash["smtp_server"]
 	if !ok {

--- a/actions_test.go
+++ b/actions_test.go
@@ -71,6 +71,16 @@ func TestEmailNotifier(t *testing.T) {
 	assert.NotNil(t, action)
 }
 
+func TestUnauthenticatedEmailNotifier(t *testing.T) {
+	t.Parallel()
+	action, err := makeAction("alert", "email", map[string]string{
+		"smtp_server": "smtp.example.com",
+		"to_email":    "mike@example.org",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, action)
+}
+
 func TestInvalidNotifier(t *testing.T) {
 	t.Parallel()
 	action, err := makeAction("alert", "emaul", map[string]string{})


### PR DESCRIPTION
This is an idea how plain and unauthenticated smtp support as requested in issue #44 could be implemented:

It changes the config parser and email strategy to assume plain and unauthenticated smtp on port 25, if no username is specified and TLS with authentication on port 587 otherwise.

Feedback welcome!
