### PR TITLE
Fix sysctl on osx with comma decimal separator

### DIFF
--- a/metrics/host.go
+++ b/metrics/host.go
@@ -108,6 +108,7 @@ func (hs *hostStorage) collectMemory() error {
 		}
 	} else {
 		cmd := exec.Command("sysctl", "-n", "vm.swapusage")
+		cmd.Env = []string{"LANG=C"}
 		sout, err := util.SafeRun(cmd)
 		if err != nil {
 			return err
@@ -179,6 +180,7 @@ func (hs *hostStorage) collectLoadAverage() error {
 		loadavgString = string(contentBytes)
 	} else {
 		cmd := exec.Command("sysctl", "-n", "vm.loadavg")
+		cmd.Env = []string{"LANG=C"}
 		sout, err := util.SafeRun(cmd)
 		if err != nil {
 			return err


### PR DESCRIPTION
Mac OS X renders floats in sysctl output according to the locale specified by LANG, which breaks parsing by strconv.parseFloat if a decimal separator other than period is used:

```
LANG=de_DE.UTF-8 make
--- FAIL: TestCollectRealHostMetrics (0.03 seconds)
    host_test.go:60: strconv.ParseFloat: parsing "2,99": invalid syntax
```

This PR changes the exec environment for the sysctl call to always set LANG=C to work around the problem.

Another approach could be to use Go's `syscall.Sysctl()`, but the current implementation doesn't handle non-string return values and eg vm.loadavg on OS X returns a struct (see `man 3 sysctl`).
