### PR TITLE
Add tls_port option for SMTP servers.

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -141,6 +141,7 @@ type EmailNotifier struct {
 	Host     string
 	From     string
 	To       string
+	TLSPort  string
 }
 
 type EmailEvent struct {
@@ -183,7 +184,7 @@ func sendEmail(e *EmailNotifier, doc bytes.Buffer) error {
 		util.Debug("Sending email:\n%s", string(doc.Bytes()))
 		if e.Username != "" {
 			auth := smtp.PlainAuth("", e.Username, e.Password, e.Host)
-			err := smtp.SendMail(e.Host+":587", auth, e.From,
+			err := smtp.SendMail(e.Host+":"+e.TLSPort, auth, e.From,
 				[]string{e.To}, doc.Bytes())
 			if err != nil {
 				return err
@@ -219,12 +220,17 @@ func (e *EmailNotifier) setup(hash map[string]string) error {
 	if !ok {
 		from = "inspeqtor@example.com"
 	}
+  tls_port, ok := hash["tls_port"]
+  if !ok {
+    tls_port = "587"
+  }
 
 	e.Username = usr
 	e.Password = pwd
 	e.Host = host
 	e.From = from
 	e.To = to
+	e.TLSPort = tls_port
 
 	return nil
 }

--- a/actions_test.go
+++ b/actions_test.go
@@ -165,7 +165,7 @@ func validProcessEvent(etype EventType) *Event {
 
 func validEmailSetup() *EmailNotifier {
 	return &EmailNotifier{
-		"mike", "fuzzbucket", "smtp.gmail.com", "mike@example.org", "mperham@gmail.com"}
+		"mike", "fuzzbucket", "smtp.gmail.com", "mike@example.org", "mperham@gmail.com", ""}
 }
 
 type TestAction struct {


### PR DESCRIPTION
This allows one to configure which port is used to connect to an SMTP server while not allowing for non-TLS connections.

This has been discussed in mperham#78

I went with `tls_port` because it enforces the fact that it is for a TLS connection.

I've compiled the inspeqtor binary and tested on a Google Compute Instance and was able to successfully send alerts through port 2525.

Let me know if you think I'm overlooking something.