### PR TITLE
Show silenced until in status output

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ See [Current Release Status](https://github.com/mperham/inspeqtor/milestones) he
 
 - Add tls_port option for SMTP servers. [exploid, #79]
 - Add gometalinter. [#83]
+- Show silenced until date in status output. [#83]
 
 ## 0.8.1-1
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,7 @@ See [Current Release Status](https://github.com/mperham/inspeqtor/milestones) he
 
 - Add tls_port option for SMTP servers. [exploid, #79]
 - Add gometalinter. [#83]
-- Show silenced until date in status output. [#83]
+- Show silenced until date in status output. [#101]
 
 ## 0.8.1-1
 

--- a/commands.go
+++ b/commands.go
@@ -131,7 +131,7 @@ func currentStatus(i *Inspeqtor, args []string, resp io.Writer) {
 		"%s %s, uptime: %s, pid: %d\n", Name, VERSION, time.Now().Sub(i.StartedAt).String(), os.Getpid()))
 
 	if i.silenced() {
-		io.WriteString(resp, fmt.Sprintf("Silenced until: %s\n", i.SilenceUntil.String()))
+		io.WriteString(resp, fmt.Sprintf("Silenced until: %s\n", i.SilenceUntil))
 	}
 
 	io.WriteString(resp, "\n")

--- a/commands.go
+++ b/commands.go
@@ -129,6 +129,11 @@ func finishDeploy(i *Inspeqtor, args []string, resp io.Writer) {
 func currentStatus(i *Inspeqtor, args []string, resp io.Writer) {
 	io.WriteString(resp, fmt.Sprintf(
 		"%s %s, uptime: %s, pid: %d\n", Name, VERSION, time.Now().Sub(i.StartedAt).String(), os.Getpid()))
+
+	if i.silenced() {
+		io.WriteString(resp, fmt.Sprintf("Silenced until: %s\n", i.SilenceUntil.String()))
+	}
+
 	io.WriteString(resp, "\n")
 
 	io.WriteString(resp, fmt.Sprintf("Host: %s\n", i.Host.Name()))

--- a/commands.go
+++ b/commands.go
@@ -131,7 +131,7 @@ func currentStatus(i *Inspeqtor, args []string, resp io.Writer) {
 		"%s %s, uptime: %s, pid: %d\n", Name, VERSION, time.Now().Sub(i.StartedAt).String(), os.Getpid()))
 
 	if i.silenced() {
-		io.WriteString(resp, fmt.Sprintf("Silenced until: %s\n", i.SilenceUntil))
+		io.WriteString(resp, fmt.Sprintf("Silenced until: %s\n", i.SilenceUntil.Format(time.RFC3339)))
 	}
 
 	io.WriteString(resp, "\n")

--- a/commands_test.go
+++ b/commands_test.go
@@ -137,6 +137,24 @@ func TestStatus(t *testing.T) {
 	assert.Equal(t, 0, idxs[0])
 }
 
+func TestStatusSilenced(t *testing.T) {
+	i, err := New("_", "")
+	assert.Nil(t, err)
+
+	proc := CommandHandlers["status"]
+
+	containsSilenced := func() bool {
+		var resp bytes.Buffer
+		proc(i, []string{}, &resp)
+		return strings.Contains(resp.String(), "Silenced until: ")
+	}
+
+	assert.False(t, containsSilenced())
+
+	i.SilenceUntil = time.Now().Add(10 * time.Second)
+	assert.True(t, containsSilenced())
+}
+
 func TestExport(t *testing.T) {
 	t.Parallel()
 	i, err := New("_", "")


### PR DESCRIPTION
This is a rough implementation of @allaire's idea in #101, I'm fairly new to inspeqtor and this issue seemed like low hanging fruit :smile: 

Here's how it looks:

```
Inspeqtor 0.8.1, uptime: 8.982152358s, pid: 6056
Silenced until: 2015-08-03 19:30:17.231342749 +0000 UTC

Host: vagrant-ubuntu-trusty-64
  cpu                                 0.0%
  cpu:iowait                          0.0%
  cpu:steal                           0.0%
  cpu:system                          0.0%
  cpu:user                            0.0%
  disk:/                              4.0%            90%
  load:1                              0.09
  load:15                             0.05
  load:5                              0.07            10
! swap                                100.0%          20%
```

Do you have a preferred date format?

Thanks! :sparkling_heart: 