### PR TITLE
Add support for multiple email recipients

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -7,6 +7,7 @@ import (
 	"net/smtp"
 	"strings"
 	"text/template"
+	"regexp"
 
 	"github.com/mperham/inspeqtor/util"
 )
@@ -182,15 +183,15 @@ func sendEmail(e *EmailNotifier, doc bytes.Buffer) error {
 	} else {
 		util.Debug("Sending email to %s", e.To)
 		util.Debug("Sending email:\n%s", string(doc.Bytes()))
+		recipients := regexp.MustCompile(`,\s*`).Split(e.To, -1)
 		if e.Username != "" {
 			auth := smtp.PlainAuth("", e.Username, e.Password, e.Host)
-			err := smtp.SendMail(e.Host+":"+e.TLSPort, auth, e.From,
-				[]string{e.To}, doc.Bytes())
+			err := smtp.SendMail(e.Host+":"+e.TLSPort, auth, e.From, recipients, doc.Bytes())
 			if err != nil {
 				return err
 			}
 		} else {
-			err := smtp.SendMail(e.Host+":25", nil, e.From, []string{e.To}, doc.Bytes())
+			err := smtp.SendMail(e.Host+":25", nil, e.From, recipients, doc.Bytes())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR solving issue #112

Configuration example:
```
send alerts via email with
  username smtpuser,
  password smtppass,
  smtp_server smtp.mailgun.org,
  to_email "user1@gmail.com, user2@gmail.com",
  from_email app.server@myserver.com
```

I'm new to Go, should this feature have test?