### PR TITLE
Fix mysql with password

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,8 @@
 Please note that the Inspeqtor codebase does not change a lot because it is
 considered feature complete and stable.  It is maintained and not a dead project.
 
+- Fix MySQL connection with password
+
 ## 1.0.1
 
 - Add binary and build support for Ubuntu 16.04 LTS (xenial)

--- a/metrics/daemon/mysql.go
+++ b/metrics/daemon/mysql.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -169,8 +170,7 @@ func (rs *mysqlSource) buildArgs() []string {
 		args = append(args, rs.Username)
 	}
 	if rs.Password != "" {
-		args = append(args, "-p")
-		args = append(args, rs.Password)
+		args = append(args, fmt.Sprintf("-p%s", rs.Password))
 	}
 
 	return args

--- a/metrics/daemon/mysql_test.go
+++ b/metrics/daemon/mysql_test.go
@@ -72,13 +72,12 @@ func TestRealMysqlConnection(t *testing.T) {
 
 func TestRealMysqlConnectionWithPassword(t *testing.T) {
 	// This test doesn't run in parallel with the other test as it changes the password from the default.
-	assert.True(t, changeMysqlPassword("", "password.test.%$'#_(@*[|~`&"), "This test will fail if your database has a password set")
-	rs := testMysqlSource(map[string]string{"password": "password.test.%$'#_(@*[|~`&"}, "Connections", "Seconds_Behind_Master")
+	assert.True(t, changeMysqlPassword("", "password   .test.%$'#_(@*[|~` &"), "This test will fail if your database has a password set")
+	rs := testMysqlSource(map[string]string{"password": "password   .test.%$'#_(@*[|~` &"}, "Connections", "Seconds_Behind_Master")
 	err := rs.Prepare()
 	assert.NotNil(t, err, "This test will fail if you don't have mysql installed")
 	assert.True(t, strings.Contains(err.Error(), "slave not running"))
-
-	rs = testMysqlSource(map[string]string{"password": "password.test.%$'#_(@*[|~`&"})
+	rs = testMysqlSource(map[string]string{"password": "password   .test.%$'#_(@*[|~` &"})
 	assert.NotNil(t, rs)
 	err = rs.Prepare()
 	assert.Nil(t, err)
@@ -86,8 +85,36 @@ func TestRealMysqlConnectionWithPassword(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, hash)
 
+	assert.True(t, changeMysqlPassword("password   .test.%$'#_(@*[|~` &", "password.test.%$'#_(@*[|~`&"), "This test will fail if your database has a password set")
+	rs = testMysqlSource(map[string]string{"password": "password.test.%$'#_(@*[|~`&"}, "Connections", "Seconds_Behind_Master")
+	err = rs.Prepare()
+	assert.NotNil(t, err, "This test will fail if you don't have mysql installed")
+	assert.True(t, strings.Contains(err.Error(), "slave not running"))
+	rs = testMysqlSource(map[string]string{"password": "password.test.%$'#_(@*[|~`&"})
+	assert.NotNil(t, rs)
+	err = rs.Prepare()
+	assert.Nil(t, err)
+	hash, err = rs.Capture()
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+
 	assert.True(t, hash["Connections"] > 0, "This test will fail if you don't have mysql installed")
 	assert.True(t, changeMysqlPassword("password.test.%$'#_(@*[|~`&", ""), "This test will fail if your database has a password set")
+
+	rs = testMysqlSource(map[string]string{}, "Connections", "Seconds_Behind_Master")
+	err = rs.Prepare()
+	assert.NotNil(t, err, "This test will fail if you don't have mysql installed")
+	assert.True(t, strings.Contains(err.Error(), "slave not running"))
+
+	rs = testMysqlSource(map[string]string{})
+	assert.NotNil(t, rs)
+	err = rs.Prepare()
+	assert.Nil(t, err)
+	hash, err = rs.Capture()
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+
+	assert.True(t, hash["Connections"] > 0, "This test will fail if you don't have mysql installed")
 }
 
 func testMysqlSource(connectionStrings map[string]string, mets ...string) *mysqlSource {

--- a/metrics/daemon/mysql_test.go
+++ b/metrics/daemon/mysql_test.go
@@ -112,7 +112,7 @@ func changeMysqlPassword(currentPassword string, newPassword string) bool {
 		args = append(args, fmt.Sprintf("-p%s", currentPassword))
 	}
 	args = append(args, "-e")
-	args = append(args, fmt.Sprintf("SET PASSWORD FOR 'root'@'localhost' = PASSWORD(\"%s\")", newPassword))
+	args = append(args, fmt.Sprintf("SET PASSWORD FOR 'root'@'localhost' = PASSWORD(\"%s\")", strings.Replace(newPassword, "'", "\\'", -1)))
 	_, err := execCmd("mysql", args, nil)
 	return (err == nil)
 }

--- a/metrics/daemon/mysql_test.go
+++ b/metrics/daemon/mysql_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestBadMysqlConfig(t *testing.T) {
 
 func TestMysqlCollection(t *testing.T) {
 	t.Parallel()
-	rs := testMysqlSource()
+	rs := testMysqlSource(map[string]string{})
 	assert.NotNil(t, rs)
 	rs.Watch("Seconds_Behind_Master")
 	assert.True(t, rs.metrics["Seconds_Behind_Master"])
@@ -53,12 +54,12 @@ func TestMysqlCollection(t *testing.T) {
 
 func TestRealMysqlConnection(t *testing.T) {
 	t.Parallel()
-	rs := testMysqlSource("Connections", "Seconds_Behind_Master")
+	rs := testMysqlSource(map[string]string{}, "Connections", "Seconds_Behind_Master")
 	err := rs.Prepare()
 	assert.NotNil(t, err, "This test will fail if you don't have mysql installed")
 	assert.True(t, strings.Contains(err.Error(), "slave not running"))
 
-	rs = testMysqlSource()
+	rs = testMysqlSource(map[string]string{})
 	assert.NotNil(t, rs)
 	err = rs.Prepare()
 	assert.Nil(t, err)
@@ -69,8 +70,28 @@ func TestRealMysqlConnection(t *testing.T) {
 	assert.True(t, hash["Connections"] > 0, "This test will fail if you don't have mysql installed")
 }
 
-func testMysqlSource(mets ...string) *mysqlSource {
-	src, err := metrics.Sources["mysql"](map[string]string{})
+func TestRealMysqlConnectionWithPassword(t *testing.T) {
+	// This test doesn't run in parallel with the other test as it changes the password from the default.
+	assert.True(t, changeMysqlPassword("", "password.test.%$'#_(@*[|~`&"), "This test will fail if your database has a password set")
+	rs := testMysqlSource(map[string]string{"password": "password.test.%$'#_(@*[|~`&"}, "Connections", "Seconds_Behind_Master")
+	err := rs.Prepare()
+	assert.NotNil(t, err, "This test will fail if you don't have mysql installed")
+	assert.True(t, strings.Contains(err.Error(), "slave not running"))
+
+	rs = testMysqlSource(map[string]string{"password": "password.test.%$'#_(@*[|~`&"})
+	assert.NotNil(t, rs)
+	err = rs.Prepare()
+	assert.Nil(t, err)
+	hash, err := rs.Capture()
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+
+	assert.True(t, hash["Connections"] > 0, "This test will fail if you don't have mysql installed")
+	assert.True(t, changeMysqlPassword("password.test.%$'#_(@*[|~`&", ""), "This test will fail if your database has a password set")
+}
+
+func testMysqlSource(connectionStrings map[string]string, mets ...string) *mysqlSource {
+	src, err := metrics.Sources["mysql"](connectionStrings)
 	if err != nil {
 		panic(err)
 	}
@@ -81,4 +102,17 @@ func testMysqlSource(mets ...string) *mysqlSource {
 		src.Watch(x)
 	}
 	return src.(*mysqlSource)
+}
+
+func changeMysqlPassword(currentPassword string, newPassword string) bool {
+	args := []string{"-B"}
+	args = append(args, "-u")
+	args = append(args, "root")
+	if currentPassword != "" {
+		args = append(args, fmt.Sprintf("-p%s", currentPassword))
+	}
+	args = append(args, "-e")
+	args = append(args, fmt.Sprintf("SET PASSWORD FOR 'root'@'localhost' = PASSWORD(\"%s\")", newPassword))
+	_, err := execCmd("mysql", args, nil)
+	return (err == nil)
 }


### PR DESCRIPTION
I was having issues getting inspeqtor to gather metrics from MySQL with a password set for the account. I found that with the append method it was putting a space between "-p" and the password but the mysql-cli wants  `--password[=password]` or `-p[password]`

I've added a test that uses the root login account, changes the password and then changes it back to default. This means it can't run in parallel as other tests will fail when the password changes.

I did find that when I was testing with MySQL 5.7 there is a additional line output 
`[Warning] Using a password on the command line`
whenever inspeqtor runs a command. I started writing some ugly code checking the version then looking for this line but thought that it should instead move to an options file for the connection. 